### PR TITLE
feat: enable CORS for local frontend dev server

### DIFF
--- a/app/api/main.py
+++ b/app/api/main.py
@@ -1,6 +1,7 @@
 import logging
 
 from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from slowapi import _rate_limit_exceeded_handler  # type: ignore[attr-defined, unused-ignore]
 from slowapi.errors import RateLimitExceeded
@@ -13,6 +14,13 @@ from app.core.security.rate_limiter import limiter
 logging.basicConfig(level=logging.INFO)
 
 app = FastAPI(title="Stardew Valley AI API")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]
 


### PR DESCRIPTION
## Summary
- Register `CORSMiddleware` on the FastAPI app to allow requests from the Vite dev server at `http://localhost:5173`
- Credentials are enabled so cookie/JWT-based auth works from the browser; all methods and headers are permitted

## Test plan
- [ ] `uvicorn app.api.main:app --reload` boots without errors
- [ ] From a browser at `http://localhost:5173`, fetch any endpoint (e.g. `/auth/login`) and confirm the response carries `Access-Control-Allow-Origin: http://localhost:5173`
- [ ] Preflight `OPTIONS` request returns 200 with the expected `Access-Control-Allow-*` headers
- [ ] Existing test suite still passes (`TestClient` bypasses CORS, so no regressions expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)